### PR TITLE
Split dockerfile repos between -classic and -next

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
       IN_DEV_CONTAINER: true
     docker:
       # DOCKERFILE_REPO: see Dockerfile note about how this is built.
-      - image: darklang/dark-base:447cd3d
+      - image: darklang/dark-classic-base:3f9204a
 
 commands:
   show-large-files-and-directories:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "dark-stable-builder",
+  "name": "dark-classic-builder",
 
   "build": {
     "context": "..",
@@ -52,7 +52,7 @@
     "8.8.4.4",
     "--ulimit=nofile=65536:65536",
     "--hostname",
-    "dark-stable-dev",
+    "dark-classic-dev",
     "--env-file",
     "config/dev",
     // "--env-file",
@@ -64,14 +64,14 @@
     "--security-opt",
     "seccomp=unconfined",
     "--label",
-    "dark-stable-dev-container",
+    "dark-classic-dev-container",
     "--workdir",
     "/home/dark/app"
   ],
 
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/dark/app,type=bind,consistency=delegated", // for local
   // If using a remote DOCKER_HOST, you need to mount a directory on the remote host
-  // "workspaceMount": "source=/home/paulbiggar/projects/stable-dark,target=/home/dark/app,type=bind,consistency=delegated",
+  // "workspaceMount": "source=/home/paulbiggar/projects/classic-dark,target=/home/dark/app,type=bind,consistency=delegated",
   "workspaceFolder": "/home/dark/app",
 
   "mounts": [
@@ -86,25 +86,25 @@
     // Bash history - uncomment this to save bash history between container restarts
     // "type=bind,src=${localEnv:HOME}${localEnv:USERPROFILE}/.dark_bash_history,dst=/home/dark/.bash_history,consistency=cached",
     // If using a remote DOCKER_HOST, you need to mount a directory on the remote host instead
-    // "type=bind,src=/home/paulbiggar/.dark_stable_bash_history,dst=/home/dark/.bash_history,consistency=cached",
+    // "type=bind,src=/home/paulbiggar/.dark_classic_bash_history,dst=/home/dark/.bash_history,consistency=cached",
 
     // Build directories
-    "type=volume,src=dark_stable_fsharp_build,dst=/home/dark/app/backend/Build",
-    "type=volume,src=dark_stable_lib,dst=/home/dark/app/lib",
-    "type=volume,src=dark_stable_node_modules,dst=/home/dark/app/node_modules",
-    "type=volume,src=dark_stable_nuget,dst=/home/dark/.nuget",
+    "type=volume,src=dark_classic_fsharp_build,dst=/home/dark/app/backend/Build",
+    "type=volume,src=dark_classic_lib,dst=/home/dark/app/lib",
+    "type=volume,src=dark_classic_node_modules,dst=/home/dark/app/node_modules",
+    "type=volume,src=dark_classic_nuget,dst=/home/dark/.nuget",
 
     // Postgres
-    "type=volume,src=pgconf_stable,dst=/etc/postgresql",
-    "type=volume,src=pglogs_stable,dst=/var/log/postgresql",
-    "type=volume,src=pgdata_stable,dst=/var/lib/postgresql",
+    "type=volume,src=pgconf_classic,dst=/etc/postgresql",
+    "type=volume,src=pglogs_classic,dst=/var/log/postgresql",
+    "type=volume,src=pgdata_classic,dst=/var/lib/postgresql",
 
     // Cloud storage
-    "type=volume,src=cloudstorage_stable,dst=/home/dark/cloud-storage",
+    "type=volume,src=cloudstorage_classic,dst=/home/dark/cloud-storage",
 
     // VSCode extensions
-    "type=volume,src=darklang-dark-stable-extension-volume,dst=/home/dark/.vscode-server/extensions",
-    "type=volume,src=darklang-dark-stable-extension-volume-insiders,dst=/home/dark/.vscode-server-insiders/extensions"
+    "type=volume,src=darklang-dark-classic-extension-volume,dst=/home/dark/.vscode-server/extensions",
+    "type=volume,src=darklang-dark-classic-extension-volume-insiders,dst=/home/dark/.vscode-server-insiders/extensions"
   ],
 
   // See https://aka.ms/vscode-remote/containers/non-root.

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@
 # change.
 
 
-FROM ubuntu:22.04 as dark-stable-base
+FROM ubuntu:22.04 AS dark-classic-base
 
-ENV FORCE_BUILD 3
+ENV FORCE_BUILD=9
 
 # Creates variables to allow builds to work on both amd64 and arm64
 ARG TARGETARCH
@@ -175,9 +175,9 @@ RUN mkdir -p bin
 # Locales
 ############################
 RUN sudo locale-gen "en_US.UTF-8"
-ENV LANGUAGE en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 
 ############################
 # Frontend
@@ -367,7 +367,7 @@ RUN sudo pip3 install -U --no-cache-dir -U crcmod \
 # Pip packages
 ############################
 RUN sudo pip3 install --no-cache-dir yq yamllint watchfiles yapf==0.32.0
-ENV PATH "$PATH:/home/dark/.local/bin"
+ENV PATH="$PATH:/home/dark/.local/bin"
 
 ####################################
 # CircleCI
@@ -472,7 +472,7 @@ RUN sudo dotnet workload install wasm-tools
 
 # formatting
 RUN dotnet tool install fantomas-tool --version 4.7.9 -g
-ENV PATH "$PATH:/home/dark/bin:/home/dark/.dotnet/tools"
+ENV PATH="$PATH:/home/dark/bin:/home/dark/.dotnet/tools"
 
 #############
 # tunnel user

--- a/scripts/build/clear-all-local-dbs
+++ b/scripts/build/clear-all-local-dbs
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker volume rm pgdata_stable pgconf_stable pglogs_stable
+docker volume rm pgdata_classic pgconf_stable pglogs_classic

--- a/scripts/build/clear-builder-volumes
+++ b/scripts/build/clear-builder-volumes
@@ -7,13 +7,13 @@ set -euo pipefail
 # Must be run from outside (stopped) container
 
 docker volume rm \
-  dark_stable_build \
-  dark_stable_dotesy \
-  dark_stable_esy \
-  dark_stable_fsharp_build \
-  dark_stable_lib \
-  dark_stable_node_modules \
-  dark_stable_nuget \
-  darklang-dark-stable-extension-volume \
-  darklang-dark-stable-extension-volume-insiders \
-  vscode-dark-stable
+  dark_classic_build \
+  dark_classic_dotesy \
+  dark_classic_esy \
+  dark_classic_fsharp_build \
+  dark_classic_lib \
+  dark_classic_node_modules \
+  dark_classic_nuget \
+  darklang-dark-classic-extension-volume \
+  darklang-dark-classic-extension-volume-insiders \
+  vscode-dark-classic

--- a/scripts/builder
+++ b/scripts/builder
@@ -39,7 +39,7 @@ if [[ ! -v NEVER_REBUILD_DOCKER ]]; then
   # Most of the work is done to enable arm64 builds, but rescript 9.1.4 won't
   # build on arm64 (10 supposedly does), and dotnet won't support building wasm
   # until dotnet 8 at the earliest.
-  docker buildx build --platform linux/amd64 -t dark-stable --build-arg uid="$(id -u)" --build-arg gid="$gid" .
+  docker buildx build --platform linux/amd64 -t dark-classic --build-arg uid="$(id -u)" --build-arg gid="$gid" .
 
   echo "Removing running containers"
   c=$(docker ps --filter "name=dark-builder" -q)
@@ -74,10 +74,10 @@ fi
 MOUNTS="--mount type=bind,src=$PWD,dst=/home/dark/app"
 
 # Avoid docker syncing everything to the host, slowing compiles down by 5x
-MOUNTS+=" --mount type=volume,src=dark_stable_fsharp_build,dst=/home/dark/app/backend/Build"
-MOUNTS+=" --mount type=volume,src=dark_stable_lib,dst=/home/dark/app/lib"
-MOUNTS+=" --mount type=volume,src=dark_stable_node_modules,dst=/home/dark/app/node_modules"
-MOUNTS+=" --mount type=volume,src=dark_stable_nuget,dst=/home/dark/.nuget"
+MOUNTS+=" --mount type=volume,src=dark_classic_fsharp_build,dst=/home/dark/app/backend/Build"
+MOUNTS+=" --mount type=volume,src=dark_classic_lib,dst=/home/dark/app/lib"
+MOUNTS+=" --mount type=volume,src=dark_classic_node_modules,dst=/home/dark/app/node_modules"
+MOUNTS+=" --mount type=volume,src=dark_classic_nuget,dst=/home/dark/.nuget"
 
 if [[ -e "$HOME/.config/gcloud" ]]; then
   MOUNTS="$MOUNTS --mount type=bind,src=$HOME/.config/gcloud,dst=/home/dark/.config/gcloud"
@@ -135,14 +135,14 @@ docker run \
   --platform linux/amd64 \
   --dns 8.8.8.8 \
   --dns 8.8.4.4 \
-  --name dark-stable-builder \
-  --hostname dark-stable-dev \
+  --name dark-classic-builder \
+  --hostname dark-classic-dev \
   --env-file "$ENV_FILE" \
   --env HOST_PWD="$PWD" \
   --env IN_DEV_CONTAINER=true \
-  -v pgconf-stable:/etc/postgresql \
-  -v pglogs-stable:/var/log/postgresql \
-  -v pgdata-stable:/var/lib/postgresql \
+  -v pgconf-classic:/etc/postgresql \
+  -v pglogs-classic:/var/log/postgresql \
+  -v pgdata-classic:/var/lib/postgresql \
   -v cloudstorage:/home/dark/cloud-storage \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -p 9000:9000 \
@@ -156,5 +156,5 @@ docker run \
   --security-opt seccomp=unconfined \
   --ulimit=nofile=65536:65536 \
   $MOUNTS \
-  dark-stable \
+  dark-classic \
   scripts/build/_build-server "${@}"

--- a/scripts/run-in-docker
+++ b/scripts/run-in-docker
@@ -21,12 +21,12 @@ done
 
 if [[ -v CURRENTLY_REBUILDING_DOCKER ]];
 then
-  NAME=$(docker ps --last 2 --filter "name=dark-stable-builder" --filter status=running --quiet | tail -n 1)
+  NAME=$(docker ps --last 2 --filter "name=dark-classic-builder" --filter status=running --quiet | tail -n 1)
 else
-  NAME=$(docker ps --last 1 --filter "name=dark-stable-builder" --filter status=running --quiet)
+  NAME=$(docker ps --last 1 --filter "name=dark-classic-builder" --filter status=running --quiet)
   # If the dev container isn't running, try the vscode container
   if [[ "${NAME}x" == "x" ]]; then
-    NAME=$(docker ps --last 1 --filter "label=dark-stable-dev-container" --filter status=running --quiet)
+    NAME=$(docker ps --last 1 --filter "label=dark-classic-dev-container" --filter status=running --quiet)
   fi
 fi
 


### PR DESCRIPTION
This follows a fork of the `dockerfile` repo to `classic-dockerfile`.

This is mostly so we're ready to hotfix dark-classic in case of emergency.