### PR TITLE
Add index to toplevel_oplists to make 'active cron lookup' cheaper

### DIFF
--- a/backend/migrations/20250422_212257_add_index_for_cron_lookups.sql
+++ b/backend/migrations/20250422_212257_add_index_for_cron_lookups.sql
@@ -1,0 +1,5 @@
+--#[no_tx]
+
+-- this index makes the 'get all active crons' a much more performant query
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_toplevel_oplists_filter
+ON toplevel_oplists (module, modifier, name, deleted)


### PR DESCRIPTION
already did this in prod; brought query down from 70ms to 8ms.
This is called quite frequently, consuming CPU time, which is what brought it to our attention.