### PR TITLE
Make brownout permanent and update messaging

### DIFF
--- a/backend/migrations/20250630_154155_prepare_for_brownout.sql
+++ b/backend/migrations/20250630_154155_prepare_for_brownout.sql
@@ -10,6 +10,12 @@ During the brownout:
 After the brownout is complete,
 - we will do a one-time backup to all data, in case anyone totally missed the brownout period
 - we will delete all accounts and canvases that do not have the keep_active flag on, along with any related data
+
+edit, post-brownout:
+the data sitting in the DB isn't really hurting us, and we're occasionally get folks
+who want to be updated to stay active, so we're just making the brownout permanent,
+and not purging _all_ of their data. That said, purging anyone who explicitly
+requests to be purged. (we have a script for that)
 */
 
 ALTER TABLE canvases ADD COLUMN keep_active BOOLEAN DEFAULT FALSE;

--- a/backend/src/ApiServer/Api/APIAddOps.fs
+++ b/backend/src/ApiServer/Api/APIAddOps.fs
@@ -42,13 +42,13 @@ module V1 =
       // This snippet short-circuits ApiServer to fail on requests to inactive canvases
       //   , while brownouts are active.
       let! canvasShouldBeKeptActive = C.shouldCanvasBeKeptActive canvasInfo.id
-      if LD.brownoutIsActive () && (not canvasShouldBeKeptActive) then
+      if not canvasShouldBeKeptActive then
         raise (
           HttpStatusException(
             410,
-            "Darklang-Classic is winding down: https://blog.darklang.com/winding-down-darklang-classic. "
+            "Darklang-Classic has been wound down: https://blog.darklang.com/winding-down-darklang-classic. "
             + "Your canvas has not been marked to be kept active - "
-            + "please reach out at classic@darklang.com if you'd like to keep your canvas active during the brownout period and beyond."
+            + "please reach out at classic@darklang.com if you'd like us to turn your canvas+access back on."
           )
         )
 

--- a/backend/src/ApiServer/Api/APIInitialLoad.fs
+++ b/backend/src/ApiServer/Api/APIInitialLoad.fs
@@ -41,13 +41,13 @@ module V1 =
       // This snippet short-circuits ApiServer to fail on requests to inactive canvases
       //   , while brownouts are active.
       let! canvasShouldBeKeptActive = Canvas.shouldCanvasBeKeptActive canvasInfo.id
-      if LD.brownoutIsActive () && (not canvasShouldBeKeptActive) then
+      if not canvasShouldBeKeptActive then
         raise (
           HttpStatusException(
             410,
-            "Darklang-Classic is winding down: https://blog.darklang.com/winding-down-darklang-classic. "
+            "Darklang-Classic has been wound down: https://blog.darklang.com/winding-down-darklang-classic. "
             + "Your canvas has not been marked to be kept active - "
-            + "please reach out at classic@darklang.com if you'd like to keep your canvas active during the brownout period and beyond."
+            + "please reach out at classic@darklang.com if you'd like us to turn your canvas+access back on."
           )
         )
 

--- a/backend/src/ApiServer/Ui.fs
+++ b/backend/src/ApiServer/Ui.fs
@@ -138,11 +138,12 @@ let accountNotActiveHtml : string =
     <body>
       <h1>Service Unavailable</h1>
       <p>
-        Darklang-Classic is winding down:
+        Darklang-Classic has been wound down:
         <a href=\"https://blog.darklang.com/winding-down-darklang-classic\">
           https://blog.darklang.com/winding-down-darklang-classic
         </a>. <br/>
-        If you see this message, your account has not been marked to be kept active - please reach out at classic@darklang.com if you'd like to keep your account active.
+        If you see this message, your account was not marked to be kept active -
+        please reach out at classic@darklang.com if you'd like us to bring your account+access back.
       </p>
     </body></html>"
 
@@ -154,12 +155,10 @@ let uiHandler (ctx : HttpContext) : Task<string> =
     use t = startTimer "read-request" ctx
     let user = loadUserInfo ctx
 
-    // We're winding down Darklang-Classic
-    // This snippet short-circuits UI access to fail for inactive accounts
-    //   while brownouts are active.
-    // The hope is that users hitting the UI will be informed of the outage
+    // This snippet short-circuits UI access to fail for inactive accounts.
+    // The hope is that users hitting the UI will be informed of the outage.
     let! accountShouldBeKeptActive = Account.shouldAccountBeKeptActive user.id
-    if LD.brownoutIsActive () && (not accountShouldBeKeptActive) then
+    if not accountShouldBeKeptActive then
       return accountNotActiveHtml
     else
       let sessionData = loadSessionData ctx

--- a/backend/src/BwdServer/Server.fs
+++ b/backend/src/BwdServer/Server.fs
@@ -231,9 +231,9 @@ let canvasNotActiveResponse (ctx : HttpContext) : Task<HttpContext> =
   Telemetry.addTag "http.completion_reason" "canvasNotActive"
   standardResponse
     ctx
-    ("Darklang-Classic is winding down: https://blog.darklang.com/winding-down-darklang-classic. "
-     + "If you see this message, your canvas has not been marked to be kept active - "
-     + "please reach out at classic@darklang.com if you'd like to keep your canvas active. "
+    ("Darklang-Classic has been wound down: https://blog.darklang.com/winding-down-darklang-classic. "
+     + "If you see this message, your canvas was not marked to be kept active - "
+     + "please reach out at classic@darklang.com if you'd like us to bring your canvas+access back."
      + "If you are not the developer of this canvas, and are a user, please contact the admin of the service you are trying to access.")
     textPlain
     410
@@ -350,7 +350,7 @@ let runDarkHandler (ctx : HttpContext) : Task<HttpContext> =
       // The hope is that users hitting those endpoints will be informed of the outage
       //   (and if those folks aren't the devs, they should tell the devs)
       let! canvasShouldBeKeptActive = Canvas.shouldCanvasBeKeptActive meta.id
-      if LD.brownoutIsActive () && (not canvasShouldBeKeptActive) then
+      if not canvasShouldBeKeptActive then
         return! canvasNotActiveResponse ctx
       else
         ctx.Items[ "canvasName" ] <- meta.name // store for exception tracking

--- a/backend/src/LibBackend/Serialize.fs
+++ b/backend/src/LibBackend/Serialize.fs
@@ -263,9 +263,8 @@ let fetchActiveCrons () : Task<List<CronScheduleData>> =
         AND modifier IS NOT NULL
         AND modifier <> ''
         AND toplevel_oplists.name IS NOT NULL
-        AND deleted IS FALSE"
-
-  let q = if LD.brownoutIsActive () then q + " AND keep_active = TRUE" else q
+        AND deleted IS FALSE
+        AND keep_active = TRUE"
 
   Sql.query q
   |> Sql.executeAsync (fun read ->

--- a/backend/src/LibService/LaunchDarkly.fs
+++ b/backend/src/LibService/LaunchDarkly.fs
@@ -296,5 +296,3 @@ let queueMaxConcurrentEventsPerWorker =
 /// Delay between fetches from the queue when something goes wrong
 let queueDelayBetweenPullsInMillis =
   Internal.intConfig "queue-delay-between-pubsub-pulls-in-millis" 1000 1000
-
-let brownoutIsActive = Internal.boolConfig "brownout-active" false false

--- a/backend/src/QueueWorker/QueueWorker.fs
+++ b/backend/src/QueueWorker/QueueWorker.fs
@@ -178,7 +178,7 @@ let processNotification
                 //   , per logic elsewhere in this file
                 let! canvasShouldBeKeptActive =
                   Canvas.shouldCanvasBeKeptActive c.meta.id
-                if LD.brownoutIsActive () && (not canvasShouldBeKeptActive) then
+                if not canvasShouldBeKeptActive then
                   let retryDelay = NodaTime.Duration.FromHours 1.0
                   return! stop "InactiveCanvas" (Retry retryDelay)
                 else


### PR DESCRIPTION
## Summary
- Remove brownout feature flag checks and make the wind-down permanent
- Update user-facing messages from "is winding down" to "has been wound down"
- Keep data retention instead of purging (users can request reactivation)

## Changes
This PR transitions Darklang Classic from a temporary brownout state to a permanent wind-down:
- Removed all `LD.brownoutIsActive()` conditional checks
- Canvas and account activity checks are now always enforced
- Updated error messages to reflect the permanent state
- Added migration note that data will be retained rather than purged
- Cron jobs now only run for canvases marked as `keep_active = TRUE`

Users who were not marked as active will see updated messaging directing them to contact classic@darklang.com if they need their canvas reactivated.