### PR TITLE
lower telemetry volume

### DIFF
--- a/backend/src/ApiServer/Http.fs
+++ b/backend/src/ApiServer/Http.fs
@@ -91,7 +91,6 @@ type HttpContextExtensions() =
     ) : Task<option<HttpContext>> =
     task {
       use t = startTimer "serialize-json" ctx
-      addTag "json_flavor" "vanilla"
       ctx.Response.ContentType <- "application/json; charset=utf-8"
       // Use a client-specific ApiServer
       let serialized = Json.Vanilla.serialize value

--- a/backend/src/ApiServer/Middleware.fs
+++ b/backend/src/ApiServer/Middleware.fs
@@ -94,10 +94,11 @@ let userInfoMiddleware : HttpMiddleware =
       | None -> return! redirectOr notFound ctx
       | Some user ->
         ctx.SetHeader("x-darklang-username", string user.username)
-        t.span ()
-        |> Telemetry.Span.addTags [ "username", sessionData.username
-                                    "userID", user.id
-                                    "is_admin", user.admin ]
+        if System.Random().Next(20) = 0 then
+          t.span ()
+          |> Telemetry.Span.addTags [ "username", sessionData.username
+                                      "userID", user.id
+                                      "is_admin", user.admin ]
         saveUserInfo user ctx
         return! next ctx
     })
@@ -172,9 +173,10 @@ let clientVersionMiddleware : HttpMiddleware =
   (fun (next : HttpHandler) (ctx : HttpContext) ->
     task {
       let clientVersion = ctx.Request.Headers.Item "x-darklang-client-version"
-      Telemetry.addTags [ "request.header.client_version", clientVersion
-                          // CLEANUP this was a bad name. Kept in until old data falls out of Honeycomb
-                          "request.header.x-darklang-client-version", clientVersion ]
+      if System.Random().Next(10) = 0 then
+        Telemetry.addTags [ "request.header.client_version", clientVersion
+                            // CLEANUP this was a bad name. Kept in until old data falls out of Honeycomb
+                            "request.header.x-darklang-client-version", clientVersion ]
       return! next ctx
     })
 

--- a/backend/src/BwdServer/Server.fs
+++ b/backend/src/BwdServer/Server.fs
@@ -424,7 +424,8 @@ let runDarkHandler (ctx : HttpContext) : Task<HttpContext> =
 
             do!
               writeResponseToContext ctx result.statusCode result.headers result.body
-            Telemetry.addTag "http.completion_reason" "success"
+            if System.Random().Next(10) = 0 then
+              Telemetry.addTag "http.completion_reason" "success"
 
             return ctx
 
@@ -473,7 +474,8 @@ let runDarkHandler (ctx : HttpContext) : Task<HttpContext> =
 
             do!
               writeResponseToContext ctx result.statusCode result.headers result.body
-            Telemetry.addTag "http.completion_reason" "success"
+            if System.Random().Next(10) = 0 then
+              Telemetry.addTag "http.completion_reason" "success"
 
             return ctx
 
@@ -493,14 +495,17 @@ let runDarkHandler (ctx : HttpContext) : Task<HttpContext> =
 
           match LegacyHttpMiddleware.Cors.optionsResponse reqHeaders meta.name with
           | Some response ->
-            Telemetry.addTag "http.completion_reason" "options response"
+            if System.Random().Next(10) = 0 then
+              Telemetry.addTag "http.completion_reason" "options response"
             do!
               writeResponseToContext
                 ctx
                 response.statusCode
                 response.headers
                 response.body
-          | None -> Telemetry.addTag "http.completion_reason" "options none"
+          | None ->
+            if System.Random().Next(10) = 0 then
+              Telemetry.addTag "http.completion_reason" "options none"
           return ctx
 
         // no matching route found - store as 404

--- a/backend/src/LibBackend/Cron.fs
+++ b/backend/src/LibBackend/Cron.fs
@@ -137,15 +137,16 @@ let checkAndScheduleWorkForCron (cron : CronScheduleData) : Task<bool> =
           delayMs
           check.interval
         |> Option.map (fun delayRatio -> ("delay_ratio", delayRatio :> obj))
-      let attrs =
-        [ ("canvas_name", cron.canvasName :> obj)
-          ("tlid", cron.tlid)
-          ("handler_name", cron.cronName)
-          // method here to use the spec-handler name for
-          // consistency with http/worker logs
-          ("method", string cron.interval) ]
-        @ ([ delayLog; intervalLog; delayRatioLog ] |> List.filterMap (fun a -> a))
-      Telemetry.addTags attrs
+      if System.Random().Next(5) = 0 then
+        let attrs =
+          [ ("canvas_name", cron.canvasName :> obj)
+            ("tlid", cron.tlid)
+            ("handler_name", cron.cronName)
+            // method here to use the spec-handler name for
+            // consistency with http/worker logs
+            ("method", string cron.interval) ]
+          @ ([ delayLog; intervalLog; delayRatioLog ] |> List.filterMap (fun a -> a))
+        Telemetry.addTags attrs
       return true
     | None -> return false
   }


### PR DESCRIPTION
We're currently producing ~133M events/mo.
If we can get to under 100M/mo, we can drop from our $585/mo subscription, to a $130/mo subscription.

I think these various efforts will lower it enough. Will edit this later with the #s.

(P.S. If we get to under 20M/mo, we can be under a free plan!)