### PR TITLE
further telem reduction efforts

### DIFF
--- a/backend/src/ApiServer/ApiServer.fs
+++ b/backend/src/ApiServer/ApiServer.fs
@@ -199,7 +199,7 @@ let configureApp (packages : Packages) (appBuilder : WebApplication) =
 let configureServices (services : IServiceCollection) : unit =
   services
   |> Rollbar.AspNet.addRollbarToServices
-  |> Telemetry.AspNet.addTelemetryToServices "ApiServer" Telemetry.TraceDBQueries
+  |> Telemetry.AspNet.addTelemetryToServices "ApiServer" Telemetry.DontTraceDBQueries
   |> Kubernetes.configureServices [ LibBackend.Canvas.healthCheck ]
   |> fun s -> s.AddServerTiming()
   |> fun s -> s.AddHsts(LibService.HSTS.setConfig)

--- a/backend/src/BwdServer/Server.fs
+++ b/backend/src/BwdServer/Server.fs
@@ -615,7 +615,7 @@ let configureServices (services : IServiceCollection) : unit =
   services
   |> Kubernetes.configureServices [ Canvas.healthCheck ]
   |> Rollbar.AspNet.addRollbarToServices
-  |> Telemetry.AspNet.addTelemetryToServices "BwdServer" Telemetry.TraceDBQueries
+  |> Telemetry.AspNet.addTelemetryToServices "BwdServer" Telemetry.DontTraceDBQueries
   |> ignore<IServiceCollection>
 
 

--- a/backend/src/QueueWorker/QueueWorker.fs
+++ b/backend/src/QueueWorker/QueueWorker.fs
@@ -353,7 +353,7 @@ let main _ : int =
     print "Starting QueueWorker"
     initSerializers ()
     LibService.Init.init name
-    Telemetry.Console.loadTelemetry name Telemetry.TraceDBQueries
+    Telemetry.Console.loadTelemetry name Telemetry.DontTraceDBQueries
     (LibBackend.Init.init LibBackend.Init.WaitForDB name).Result
     (LibRealExecution.Init.init name).Result
 


### PR DESCRIPTION
The #58 recent efforts didn't help at all. Also, updating the LaunchDarkly telemetry sampling rate from 100% to 20% didn't work. Trying here to mostly reduce the DB telem noise.