### PR TITLE
Update how we install node 14 because some keys expired

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,8 @@ RUN DEBIAN_FRONTEND=noninteractive \
       && apt clean \
       && rm -rf /var/lib/apt/lists/*
 
-# Latest NPM (taken from  https://deb.nodesource.com/setup_8.x )
-RUN curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+# Note: Node.js 14 is installed directly from nodejs.org binaries below (not via apt)
+# because NodeSource deprecated the Node 14 repository after EOL (April 2023)
 RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
@@ -71,8 +71,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg ma
 
 RUN echo "deb https://nginx.org/packages/ubuntu/ jammy nginx" > /etc/apt/sources.list.d/nginx.list
 
-RUN echo "deb https://deb.nodesource.com/node_14.x jammy main" > /etc/apt/sources.list.d/nodesource.list
-RUN echo "deb-src https://deb.nodesource.com/node_14.x jammy main" >> /etc/apt/sources.list.d/nodesource.list
+# NodeSource repo removed - Node 14 installed from official binaries below
 
 RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN echo "deb [arch=${TARGETARCH}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
@@ -110,7 +109,6 @@ RUN DEBIAN_FRONTEND=noninteractive \
       postgresql-client-13 \
       postgresql-contrib-13 \
       git-restore-mtime \
-      nodejs \
       libgbm1 \
       google-cloud-sdk \
       google-cloud-sdk-pubsub-emulator \
@@ -177,6 +175,27 @@ RUN sudo locale-gen "en_US.UTF-8"
 ENV LANGUAGE=en_US.UTF-8
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
+
+############################
+# Node.js 14 (installed from official binaries since NodeSource deprecated Node 14)
+############################
+RUN <<EOF
+set -e
+NODE_VERSION=14.21.3
+case ${TARGETARCH} in
+  arm64) ARCH=arm64 ;;
+  amd64) ARCH=x64 ;;
+  *) exit 1;;
+esac
+curl -fsSL https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${ARCH}.tar.xz -o node.tar.xz
+sudo mkdir -p /usr/local/lib/nodejs
+sudo tar -xJf node.tar.xz -C /usr/local/lib/nodejs
+sudo ln -sf /usr/local/lib/nodejs/node-v${NODE_VERSION}-linux-${ARCH}/bin/node /usr/bin/node
+sudo ln -sf /usr/local/lib/nodejs/node-v${NODE_VERSION}-linux-${ARCH}/bin/npm /usr/bin/npm
+sudo ln -sf /usr/local/lib/nodejs/node-v${NODE_VERSION}-linux-${ARCH}/bin/npx /usr/bin/npx
+rm node.tar.xz
+node --version
+EOF
 
 ############################
 # Frontend


### PR DESCRIPTION
I had to run the devcontainer locally and ran into an issue with the way we installed node 14. This allowed me to get past that locally. Worth revisiting next time we need to touch -classic.